### PR TITLE
Add product dashboard pages

### DIFF
--- a/nextjs-app/README.md
+++ b/nextjs-app/README.md
@@ -1,0 +1,15 @@
+# Next.js Projesi
+
+Bu dizin, basit bir Next.js projesi icerir. Projeyi gelistirmek icin
+asagidaki komutlari kullanabilirsiniz:
+
+```bash
+npm install
+npm run dev
+```
+
+Ardindan tarayicinizda `http://localhost:3000` adresini ziyaret edin.
+
+## Dashboard
+
+`/dashboard` altinda urun olusturma ve listeleme sayfalari ile Trendyol ve Hepsiburada urunleri sayfalari bulunur.

--- a/nextjs-app/next.config.js
+++ b/nextjs-app/next.config.js
@@ -1,0 +1,6 @@
+/** @type {import('next').NextConfig} */
+const nextConfig = {
+  reactStrictMode: true,
+};
+
+module.exports = nextConfig;

--- a/nextjs-app/package.json
+++ b/nextjs-app/package.json
@@ -1,0 +1,14 @@
+{
+  "name": "nextjs-app",
+  "version": "1.0.0",
+  "scripts": {
+    "dev": "next dev",
+    "build": "next build",
+    "start": "next start"
+  },
+  "dependencies": {
+    "next": "latest",
+    "react": "latest",
+    "react-dom": "latest"
+  }
+}

--- a/nextjs-app/pages/dashboard/create.js
+++ b/nextjs-app/pages/dashboard/create.js
@@ -1,0 +1,30 @@
+import { useState } from 'react';
+
+export default function CreateProduct() {
+  const [name, setName] = useState('');
+  const [description, setDescription] = useState('');
+
+  const handleSubmit = (e) => {
+    e.preventDefault();
+    alert(`Ürün oluşturuldu: ${name}`);
+    setName('');
+    setDescription('');
+  };
+
+  return (
+    <div>
+      <h1>Ürün Oluştur</h1>
+      <form onSubmit={handleSubmit}>
+        <div>
+          <label>Adı: </label>
+          <input value={name} onChange={(e) => setName(e.target.value)} required />
+        </div>
+        <div>
+          <label>Açıklama: </label>
+          <textarea value={description} onChange={(e) => setDescription(e.target.value)} required />
+        </div>
+        <button type="submit">Kaydet</button>
+      </form>
+    </div>
+  );
+}

--- a/nextjs-app/pages/dashboard/hepsiburada.js
+++ b/nextjs-app/pages/dashboard/hepsiburada.js
@@ -1,0 +1,8 @@
+export default function HepsiburadaProducts() {
+  return (
+    <div>
+      <h1>Hepsiburada Ürünleri</h1>
+      <p>Bu sayfada Hepsiburada ürünleri listelenecek.</p>
+    </div>
+  );
+}

--- a/nextjs-app/pages/dashboard/index.js
+++ b/nextjs-app/pages/dashboard/index.js
@@ -1,0 +1,15 @@
+import Link from 'next/link';
+
+export default function Dashboard() {
+  return (
+    <div>
+      <h1>Dashboard</h1>
+      <ul>
+        <li><Link href="/dashboard/create">Ürün Oluştur</Link></li>
+        <li><Link href="/dashboard/list">Ürün Listesi</Link></li>
+        <li><Link href="/dashboard/trendyol">Trendyol Ürünleri</Link></li>
+        <li><Link href="/dashboard/hepsiburada">Hepsiburada Ürünleri</Link></li>
+      </ul>
+    </div>
+  );
+}

--- a/nextjs-app/pages/dashboard/list.js
+++ b/nextjs-app/pages/dashboard/list.js
@@ -1,0 +1,17 @@
+export default function ProductList() {
+  const products = [
+    { id: 1, name: 'Örnek Ürün 1' },
+    { id: 2, name: 'Örnek Ürün 2' },
+  ];
+
+  return (
+    <div>
+      <h1>Ürün Listesi</h1>
+      <ul>
+        {products.map((p) => (
+          <li key={p.id}>{p.name}</li>
+        ))}
+      </ul>
+    </div>
+  );
+}

--- a/nextjs-app/pages/dashboard/trendyol.js
+++ b/nextjs-app/pages/dashboard/trendyol.js
@@ -1,0 +1,8 @@
+export default function TrendyolProducts() {
+  return (
+    <div>
+      <h1>Trendyol Ürünleri</h1>
+      <p>Bu sayfada Trendyol ürünleri listelenecek.</p>
+    </div>
+  );
+}

--- a/nextjs-app/pages/index.js
+++ b/nextjs-app/pages/index.js
@@ -1,0 +1,13 @@
+import Link from 'next/link';
+
+export default function Home() {
+  return (
+    <div>
+      <h1>Merhaba Next.js</h1>
+      <p>Bu basit bir Next.js projesidir.</p>
+      <p>
+        <Link href="/dashboard">Dashboarda Git</Link>
+      </p>
+    </div>
+  );
+}


### PR DESCRIPTION
## Summary
- add link to new dashboard on homepage
- implement dashboard with product creation, listing, Trendyol and Hepsiburada pages
- document new dashboard in README

## Testing
- `npm test` *(fails: Missing script)*
- `npm run build` *(fails: next not found)*

------
https://chatgpt.com/codex/tasks/task_b_686585b062cc832eae513a3c9a9c137e