### PR TITLE
Add DreamTracker AI Compose app

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,10 +1,21 @@
-- 👋 Hi, I’m @Oktay-Bey
-- 👀 I’m interested in web developing and digital marketing
-- 🌱 I’m currently learning HTML, CSS, PHP, WordPress
-- 💞️ I’m looking to collaborate on ...
-- 📫 How to reach me ...
+# DreamTracker AI
 
-<!---
-Oktay-Bey/Oktay-Bey is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
-You can click the Preview link to take a look at your changes.
---->
+Android Studio ile uyumlu bu örnek proje, rüyalarınızı kaydetmenize, geçmiş kayıtları görüntülemenize ve basit yapay zekâ destekli analizler üretmenize yardımcı olur. Kodlar `dream-diary/` klasörü altında Kotlin + Jetpack Compose kullanılarak hazırlanmıştır.
+
+## Öne Çıkan Özellikler
+- 📓 Başlık, açıklama, etiket, ruh hâli ve lucidlik yüzdesi ile rüya kaydı
+- 🤖 Anahtar kelime tabanlı DreamAnalyzer sınıfı ile çevrimdışı yapay zekâ analizi
+- 📊 Anlık ruh hâli/detay kartları ve uyku önerileri
+- 🧱 MVVM mimarisi, Compose Material 3 tasarımı ve StateFlow tabanlı durum yönetimi
+
+## Çalıştırma
+1. Android Studio (Giraffe+), Android SDK 34 ve JDK 17 kurulu olmalıdır.
+2. `dream-diary` klasörünü Android Studio ile açın.
+3. Gerekli Gradle bağımlılıkları otomatik olarak indirilecektir.
+4. Bir emülatör veya fiziksel cihaz seçip **Run ▶** düğmesine basın.
+
+## Yapay Zekâ Analizi Nasıl Çalışır?
+`DreamAnalyzer` sınıfı rüya açıklamasındaki sembolleri ve ruh hâlini basit kurallarla puanlar. Gerçek bir projede bu katmana OpenAI, Vertex AI ya da on-device MLKit modelleri bağlanabilir. Entegrasyon noktaları koda yorum olarak eklenmiştir.
+
+## Ekran Görüntüsü
+Uygulama Compose bileşenleri ile modern bir kart düzeni kullanır; en üstte rüya ekleme formu, altında AI özetlerini içeren kart listesi bulunur.

--- a/dream-diary/app/build.gradle.kts
+++ b/dream-diary/app/build.gradle.kts
@@ -1,0 +1,59 @@
+plugins {
+    id("com.android.application")
+    id("org.jetbrains.kotlin.android")
+}
+
+android {
+    namespace = "com.oktaybe.dreamtracker"
+    compileSdk = 34
+
+    defaultConfig {
+        applicationId = "com.oktaybe.dreamtracker"
+        minSdk = 24
+        targetSdk = 34
+        versionCode = 1
+        versionName = "1.0"
+
+        testInstrumentationRunner = "androidx.test.runner.AndroidJUnitRunner"
+    }
+
+    buildTypes {
+        release {
+            isMinifyEnabled = false
+            proguardFiles(
+                getDefaultProguardFile("proguard-android-optimize.txt"),
+                "proguard-rules.pro"
+            )
+        }
+    }
+
+    buildFeatures {
+        compose = true
+    }
+
+    composeOptions {
+        kotlinCompilerExtensionVersion = "1.5.8"
+    }
+
+    packaging {
+        resources {
+            excludes += "/META-INF/{AL2.0,LGPL2.1}"
+        }
+    }
+}
+
+dependencies {
+    implementation("androidx.core:core-ktx:1.12.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-ktx:2.7.0")
+    implementation("androidx.activity:activity-compose:1.8.2")
+    implementation(platform("androidx.compose:compose-bom:2024.02.01"))
+    implementation("androidx.compose.ui:ui")
+    implementation("androidx.compose.ui:ui-tooling-preview")
+    implementation("androidx.compose.material3:material3")
+    implementation("androidx.lifecycle:lifecycle-viewmodel-compose:2.7.0")
+    implementation("androidx.lifecycle:lifecycle-runtime-compose:2.7.0")
+    implementation("org.jetbrains.kotlinx:kotlinx-coroutines-android:1.7.3")
+
+    debugImplementation("androidx.compose.ui:ui-tooling")
+    debugImplementation("androidx.compose.ui:ui-test-manifest")
+}

--- a/dream-diary/app/src/main/AndroidManifest.xml
+++ b/dream-diary/app/src/main/AndroidManifest.xml
@@ -1,0 +1,25 @@
+<?xml version="1.0" encoding="utf-8"?>
+<manifest xmlns:android="http://schemas.android.com/apk/res/android">
+
+    <application
+        android:allowBackup="true"
+        android:dataExtractionRules="@xml/data_extraction_rules"
+        android:fullBackupContent="@xml/backup_rules"
+        android:icon="@mipmap/ic_launcher"
+        android:label="@string/app_name"
+        android:roundIcon="@mipmap/ic_launcher_round"
+        android:supportsRtl="true"
+        android:theme="@style/Theme.DreamTrackerAI">
+        <activity
+            android:name=".MainActivity"
+            android:exported="true"
+            android:theme="@style/Theme.DreamTrackerAI">
+            <intent-filter>
+                <action android:name="android.intent.action.MAIN" />
+
+                <category android:name="android.intent.category.LAUNCHER" />
+            </intent-filter>
+        </activity>
+    </application>
+
+</manifest>

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/DreamViewModel.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/DreamViewModel.kt
@@ -1,0 +1,59 @@
+package com.oktaybe.dreamtracker
+
+import androidx.lifecycle.ViewModel
+import androidx.lifecycle.ViewModelProvider
+import androidx.lifecycle.viewModelScope
+import com.oktaybe.dreamtracker.data.Dream
+import com.oktaybe.dreamtracker.data.DreamMood
+import com.oktaybe.dreamtracker.data.DreamRepository
+import kotlinx.coroutines.flow.SharingStarted
+import kotlinx.coroutines.flow.StateFlow
+import kotlinx.coroutines.flow.map
+import kotlinx.coroutines.flow.stateIn
+import kotlinx.coroutines.launch
+
+data class DreamUiState(
+    val dreams: List<Dream> = emptyList(),
+    val title: String = "",
+    val description: String = "",
+    val mood: DreamMood = DreamMood.NEUTRAL,
+    val lucidity: Float = 50f,
+    val tags: String = ""
+)
+
+class DreamViewModel(
+    private val repository: DreamRepository
+) : ViewModel() {
+
+    private val dreamsFlow = repository.observeDreams()
+
+    val uiState: StateFlow<DreamUiState> = dreamsFlow
+        .map { DreamUiState(dreams = it) }
+        .stateIn(
+            scope = viewModelScope,
+            started = SharingStarted.WhileSubscribed(5_000),
+            initialValue = DreamUiState(dreams = emptyList())
+        )
+
+    fun addDream(title: String, description: String, mood: DreamMood, lucidity: Int, tags: String) {
+        if (title.isBlank() || description.isBlank()) return
+        viewModelScope.launch {
+            repository.addDream(
+                title = title,
+                description = description,
+                mood = mood,
+                lucidity = lucidity,
+                tags = tags.split(',').map { it.trim() }.filter { it.isNotEmpty() }
+            )
+        }
+    }
+
+    companion object {
+        val Factory = object : ViewModelProvider.Factory {
+            override fun <T : ViewModel> create(modelClass: Class<T>): T {
+                val repo = DreamRepository()
+                return DreamViewModel(repo) as T
+            }
+        }
+    }
+}

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/MainActivity.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/MainActivity.kt
@@ -1,0 +1,228 @@
+package com.oktaybe.dreamtracker
+
+import android.os.Bundle
+import androidx.activity.ComponentActivity
+import androidx.activity.compose.setContent
+import androidx.activity.viewModels
+import androidx.compose.foundation.layout.Arrangement
+import androidx.compose.foundation.layout.Column
+import androidx.compose.foundation.layout.ExperimentalLayoutApi
+import androidx.compose.foundation.layout.FlowRow
+import androidx.compose.foundation.layout.Spacer
+import androidx.compose.foundation.layout.fillMaxSize
+import androidx.compose.foundation.layout.fillMaxWidth
+import androidx.compose.foundation.layout.height
+import androidx.compose.foundation.layout.padding
+import androidx.compose.foundation.lazy.LazyColumn
+import androidx.compose.foundation.lazy.items
+import androidx.compose.material.icons.Icons
+import androidx.compose.material.icons.filled.AutoAwesome
+import androidx.compose.material.icons.filled.Bedtime
+import androidx.compose.material3.Button
+import androidx.compose.material3.Card
+import androidx.compose.material3.CardDefaults
+import androidx.compose.material3.ExperimentalMaterial3Api
+import androidx.compose.material3.Icon
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.OutlinedTextField
+import androidx.compose.material3.Slider
+import androidx.compose.material3.Text
+import androidx.compose.material3.TextButton
+import androidx.compose.material3.TopAppBar
+import androidx.compose.material3.TopAppBarDefaults
+import androidx.compose.runtime.Composable
+import androidx.compose.runtime.getValue
+import androidx.compose.runtime.mutableStateOf
+import androidx.compose.runtime.remember
+import androidx.compose.runtime.setValue
+import androidx.compose.ui.Modifier
+import androidx.compose.ui.res.stringResource
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.dp
+import androidx.lifecycle.compose.collectAsStateWithLifecycle
+import com.oktaybe.dreamtracker.data.Dream
+import com.oktaybe.dreamtracker.data.DreamMood
+import com.oktaybe.dreamtracker.ui.theme.DreamTrackerTheme
+
+class MainActivity : ComponentActivity() {
+    private val viewModel: DreamViewModel by viewModels { DreamViewModel.Factory }
+
+    override fun onCreate(savedInstanceState: Bundle?) {
+        super.onCreate(savedInstanceState)
+        setContent {
+            DreamTrackerTheme {
+                DreamTrackerApp(viewModel)
+            }
+        }
+    }
+}
+
+@OptIn(ExperimentalMaterial3Api::class)
+@Composable
+fun DreamTrackerApp(viewModel: DreamViewModel) {
+    val uiState by viewModel.uiState.collectAsStateWithLifecycle()
+    var title by remember { mutableStateOf("") }
+    var description by remember { mutableStateOf("") }
+    var mood by remember { mutableStateOf(DreamMood.NEUTRAL) }
+    var tags by remember { mutableStateOf("") }
+    var lucidity by remember { mutableStateOf(50f) }
+
+    Column(
+        modifier = Modifier
+            .fillMaxSize()
+            .padding(16.dp)
+    ) {
+        TopAppBar(
+            title = { Text(stringResource(id = R.string.dream_list_title)) },
+            colors = TopAppBarDefaults.topAppBarColors(
+                containerColor = MaterialTheme.colorScheme.primary,
+                titleContentColor = MaterialTheme.colorScheme.onPrimary
+            ),
+            navigationIcon = {
+                Icon(
+                    imageVector = Icons.Default.Bedtime,
+                    contentDescription = null,
+                    tint = MaterialTheme.colorScheme.onPrimary
+                )
+            },
+            actions = {
+                Icon(
+                    imageVector = Icons.Default.AutoAwesome,
+                    contentDescription = "AI"
+                )
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        DreamForm(
+            title = title,
+            onTitleChange = { title = it },
+            description = description,
+            onDescriptionChange = { description = it },
+            mood = mood,
+            onMoodChange = { mood = it },
+            tags = tags,
+            onTagsChange = { tags = it },
+            lucidity = lucidity,
+            onLucidityChange = { lucidity = it },
+            onSave = {
+                viewModel.addDream(title, description, mood, lucidity.toInt(), tags)
+                title = ""
+                description = ""
+                tags = ""
+                lucidity = 50f
+                mood = DreamMood.NEUTRAL
+            }
+        )
+
+        Spacer(modifier = Modifier.height(16.dp))
+
+        DreamList(dreams = uiState.dreams)
+    }
+}
+
+@Composable
+private fun DreamForm(
+    title: String,
+    onTitleChange: (String) -> Unit,
+    description: String,
+    onDescriptionChange: (String) -> Unit,
+    mood: DreamMood,
+    onMoodChange: (DreamMood) -> Unit,
+    tags: String,
+    onTagsChange: (String) -> Unit,
+    lucidity: Float,
+    onLucidityChange: (Float) -> Unit,
+    onSave: () -> Unit
+) {
+    Card(
+        modifier = Modifier.fillMaxWidth(),
+        colors = CardDefaults.cardColors(containerColor = MaterialTheme.colorScheme.surface)
+    ) {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = stringResource(id = R.string.add_dream), style = MaterialTheme.typography.titleLarge)
+            OutlinedTextField(
+                value = title,
+                onValueChange = onTitleChange,
+                label = { Text("Rüya Başlığı") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            OutlinedTextField(
+                value = description,
+                onValueChange = onDescriptionChange,
+                label = { Text("Detaylar") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            MoodSelector(selectedMood = mood, onMoodChange = onMoodChange)
+            OutlinedTextField(
+                value = tags,
+                onValueChange = onTagsChange,
+                label = { Text("Etiketler (virgülle ayırın)") },
+                modifier = Modifier.fillMaxWidth()
+            )
+            Text(text = "Lucidlik: ${lucidity.toInt()}%")
+            Slider(
+                value = lucidity,
+                onValueChange = onLucidityChange,
+                valueRange = 0f..100f
+            )
+            Button(onClick = onSave, modifier = Modifier.fillMaxWidth()) {
+                Text("Kaydet")
+            }
+        }
+    }
+}
+
+@Composable
+private fun MoodSelector(selectedMood: DreamMood, onMoodChange: (DreamMood) -> Unit) {
+    Column(verticalArrangement = Arrangement.spacedBy(8.dp)) {
+        Text(text = "Ruh Hali", style = MaterialTheme.typography.titleMedium)
+        MoodChipRow(selectedMood = selectedMood, onMoodChange = onMoodChange)
+    }
+}
+
+@OptIn(ExperimentalLayoutApi::class)
+@Composable
+private fun MoodChipRow(selectedMood: DreamMood, onMoodChange: (DreamMood) -> Unit) {
+    FlowRow(
+        horizontalArrangement = Arrangement.spacedBy(8.dp)
+    ) {
+        DreamMood.values().forEach { mood ->
+            TextButton(onClick = { onMoodChange(mood) }) {
+                Text(
+                    text = mood.displayName,
+                    fontWeight = if (mood == selectedMood) FontWeight.Bold else FontWeight.Normal
+                )
+            }
+        }
+    }
+}
+
+@Composable
+private fun DreamList(dreams: List<Dream>) {
+    if (dreams.isEmpty()) {
+        Text(text = stringResource(id = R.string.empty_state))
+        return
+    }
+
+    LazyColumn(verticalArrangement = Arrangement.spacedBy(12.dp)) {
+        items(dreams) { dream ->
+            DreamCard(dream)
+        }
+    }
+}
+
+@Composable
+private fun DreamCard(dream: Dream) {
+    Card {
+        Column(modifier = Modifier.padding(16.dp)) {
+            Text(text = dream.title, style = MaterialTheme.typography.titleLarge)
+            Text(text = dream.description)
+            Text(text = "Ruh Hali: ${dream.mood.displayName}")
+            Text(text = "Lucidlik: ${dream.lucidity}%")
+            Text(text = "AI Özeti: ${dream.analysis.summary}")
+            Text(text = dream.analysis.sleepAdvice)
+        }
+    }
+}

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/data/Dream.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/data/Dream.kt
@@ -1,0 +1,29 @@
+package com.oktaybe.dreamtracker.data
+
+import java.time.LocalDateTime
+
+enum class DreamMood(val displayName: String) {
+    PEACEFUL("Sakin"),
+    HAPPY("Mutlu"),
+    NEUTRAL("Dengeli"),
+    ANXIOUS("Kaygılı"),
+    NIGHTMARE("Kabus")
+}
+
+data class DreamAnalysis(
+    val summary: String,
+    val dominantSymbols: List<String>,
+    val moodScore: Int,
+    val sleepAdvice: String
+)
+
+data class Dream(
+    val id: Long,
+    val title: String,
+    val description: String,
+    val mood: DreamMood,
+    val lucidity: Int,
+    val tags: List<String>,
+    val recordedAt: LocalDateTime,
+    val analysis: DreamAnalysis
+)

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/data/DreamAnalyzer.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/data/DreamAnalyzer.kt
@@ -1,0 +1,56 @@
+package com.oktaybe.dreamtracker.data
+
+import java.util.Locale
+
+/**
+ * Basit kurallara dayalı analiz sınıfı. Gerçek uygulamada
+ * burada bir bulut API'si veya on-device ML modeli entegre edilebilir.
+ */
+class DreamAnalyzer {
+    private val nightmareKeywords = listOf("karanlık", "kovaladı", "düştüm", "savaş")
+    private val lucidKeywords = listOf("fark ettim", "kontrol ettim", "bilinçli")
+
+    fun analyze(text: String, tags: List<String>): DreamAnalysis {
+        val lower = text.lowercase(Locale.getDefault())
+        val dominantSymbols = tags.takeIf { it.isNotEmpty() }
+            ?: extractSymbols(lower)
+
+        val moodScore = when {
+            nightmareKeywords.any { lower.contains(it) } -> 15
+            lower.contains("deniz") || lower.contains("uçmak") -> 80
+            else -> 55
+        }
+
+        val lucidityHint = if (lucidKeywords.any { lower.contains(it) }) {
+            "Rüya sırasında bilincin arttığına dair ipuçları bulunuyor."
+        } else {
+            "Lucid farkındalık belirtileri sınırlı, uyku öncesi nefes egzersizleri ekleyin."
+        }
+
+        val summary = buildString {
+            append("Metinden çıkarılan semboller: ")
+            append(dominantSymbols.joinToString())
+            append(". Genel ruh hali puanı: $moodScore.")
+        }
+
+        val advice = if (moodScore < 30) {
+            "Negatif duygu yoğunluğu yüksek. Gün içinde kısa yürüyüşler ve günlük tutma önerilir."
+        } else {
+            "Uyku hijyenini korumak için düzenli uyku saatleri ve hafif esneme rutini uygulayın."
+        }
+
+        return DreamAnalysis(
+            summary = summary,
+            dominantSymbols = dominantSymbols,
+            moodScore = moodScore,
+            sleepAdvice = "$lucidityHint $advice"
+        )
+    }
+
+    private fun extractSymbols(text: String): List<String> {
+        return text.split(" ")
+            .map { it.replace(Regex("[^a-zA-ZçğıöşüÇĞİÖŞÜ]"), "") }
+            .filter { it.length > 3 }
+            .take(4)
+    }
+}

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/data/DreamRepository.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/data/DreamRepository.kt
@@ -1,0 +1,55 @@
+package com.oktaybe.dreamtracker.data
+
+import kotlinx.coroutines.flow.Flow
+import kotlinx.coroutines.flow.MutableStateFlow
+import kotlinx.coroutines.flow.asStateFlow
+import kotlinx.coroutines.flow.update
+import java.time.LocalDateTime
+
+class DreamRepository(
+    private val analyzer: DreamAnalyzer = DreamAnalyzer()
+) {
+    private val dreams = MutableStateFlow(sampleDreams())
+
+    fun observeDreams(): Flow<List<Dream>> = dreams.asStateFlow()
+
+    fun addDream(
+        title: String,
+        description: String,
+        mood: DreamMood,
+        lucidity: Int,
+        tags: List<String>
+    ) {
+        val analysis = analyzer.analyze(description, tags)
+        val dream = Dream(
+            id = System.currentTimeMillis(),
+            title = title,
+            description = description,
+            mood = mood,
+            lucidity = lucidity,
+            tags = tags,
+            recordedAt = LocalDateTime.now(),
+            analysis = analysis
+        )
+        dreams.update { listOf(dream) + it }
+    }
+
+    private fun sampleDreams(): List<Dream> {
+        val defaultAnalysis = analyzer.analyze(
+            text = "Deniz üstünde uçarken kendimi kontrol ediyordum",
+            tags = listOf("deniz", "uçmak", "özgürlük")
+        )
+        return listOf(
+            Dream(
+                id = 1,
+                title = "Bulutların Üstünde",
+                description = "Geniş bir denizde yüzdükten sonra bulutların üstüne çıktım.",
+                mood = DreamMood.HAPPY,
+                lucidity = 70,
+                tags = listOf("deniz", "bulut"),
+                recordedAt = LocalDateTime.now().minusDays(1),
+                analysis = defaultAnalysis
+            )
+        )
+    }
+}

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/ui/theme/Color.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/ui/theme/Color.kt
@@ -1,0 +1,9 @@
+package com.oktaybe.dreamtracker.ui.theme
+
+import androidx.compose.ui.graphics.Color
+
+val Purple40 = Color(0xFF6750A4)
+val PurpleGrey40 = Color(0xFF625B71)
+val Pink40 = Color(0xFF7D5260)
+val MidnightBlue = Color(0xFF0D1B2A)
+val DreamyLavender = Color(0xFFD7C7F7)

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/ui/theme/Theme.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/ui/theme/Theme.kt
@@ -1,0 +1,40 @@
+package com.oktaybe.dreamtracker.ui.theme
+
+import androidx.compose.foundation.isSystemInDarkTheme
+import androidx.compose.material3.MaterialTheme
+import androidx.compose.material3.darkColorScheme
+import androidx.compose.material3.lightColorScheme
+import androidx.compose.runtime.Composable
+import androidx.compose.ui.graphics.Color
+
+private val DarkColorScheme = darkColorScheme(
+    primary = DreamyLavender,
+    secondary = PurpleGrey40,
+    background = MidnightBlue,
+    surface = MidnightBlue,
+    onPrimary = Color.Black,
+    onSecondary = Color.White
+)
+
+private val LightColorScheme = lightColorScheme(
+    primary = Purple40,
+    secondary = PurpleGrey40,
+    background = Color(0xFFF7F2FF),
+    surface = Color.White,
+    onPrimary = Color.White,
+    onSecondary = Color.Black
+)
+
+@Composable
+fun DreamTrackerTheme(
+    darkTheme: Boolean = isSystemInDarkTheme(),
+    content: @Composable () -> Unit
+) {
+    val colorScheme = if (darkTheme) DarkColorScheme else LightColorScheme
+
+    MaterialTheme(
+        colorScheme = colorScheme,
+        typography = Typography,
+        content = content
+    )
+}

--- a/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/ui/theme/Type.kt
+++ b/dream-diary/app/src/main/java/com/oktaybe/dreamtracker/ui/theme/Type.kt
@@ -1,0 +1,20 @@
+package com.oktaybe.dreamtracker.ui.theme
+
+import androidx.compose.material3.Typography
+import androidx.compose.ui.text.TextStyle
+import androidx.compose.ui.text.font.FontFamily
+import androidx.compose.ui.text.font.FontWeight
+import androidx.compose.ui.unit.sp
+
+val Typography = Typography(
+    titleLarge = TextStyle(
+        fontFamily = FontFamily.Serif,
+        fontWeight = FontWeight.Bold,
+        fontSize = 24.sp
+    ),
+    bodyMedium = TextStyle(
+        fontFamily = FontFamily.SansSerif,
+        fontWeight = FontWeight.Normal,
+        fontSize = 14.sp
+    )
+)

--- a/dream-diary/app/src/main/res/values/colors.xml
+++ b/dream-diary/app/src/main/res/values/colors.xml
@@ -1,0 +1,6 @@
+<resources>
+    <color name="md_theme_primary">#6750A4</color>
+    <color name="md_theme_onPrimary">#FFFFFF</color>
+    <color name="md_theme_secondary">#7A757F</color>
+    <color name="md_theme_background">#FFFBFE</color>
+</resources>

--- a/dream-diary/app/src/main/res/values/strings.xml
+++ b/dream-diary/app/src/main/res/values/strings.xml
@@ -1,0 +1,6 @@
+<resources>
+    <string name="app_name">DreamTracker AI</string>
+    <string name="dream_list_title">Rüya Günlüğü</string>
+    <string name="add_dream">Yeni Rüya Kaydı</string>
+    <string name="empty_state">Henüz kayıtlı rüya yok. Yukarıdaki formu kullanarak ilk notunuzu ekleyin.</string>
+</resources>

--- a/dream-diary/app/src/main/res/values/themes.xml
+++ b/dream-diary/app/src/main/res/values/themes.xml
@@ -1,0 +1,7 @@
+<resources xmlns:tools="http://schemas.android.com/tools">
+    <style name="Theme.DreamTrackerAI" parent="Theme.Material3.DayNight.NoActionBar">
+        <item name="colorPrimary">@color/md_theme_primary</item>
+        <item name="colorOnPrimary">@color/md_theme_onPrimary</item>
+        <item name="android:statusBarColor" tools:targetApi="l">@color/md_theme_primary</item>
+    </style>
+</resources>

--- a/dream-diary/app/src/main/res/xml/backup_rules.xml
+++ b/dream-diary/app/src/main/res/xml/backup_rules.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<full-backup-content />

--- a/dream-diary/app/src/main/res/xml/data_extraction_rules.xml
+++ b/dream-diary/app/src/main/res/xml/data_extraction_rules.xml
@@ -1,0 +1,2 @@
+<?xml version="1.0" encoding="utf-8"?>
+<data-extraction-rules />

--- a/dream-diary/build.gradle.kts
+++ b/dream-diary/build.gradle.kts
@@ -1,0 +1,4 @@
+plugins {
+    id("com.android.application") version "8.2.2" apply false
+    id("org.jetbrains.kotlin.android") version "1.9.22" apply false
+}

--- a/dream-diary/gradle.properties
+++ b/dream-diary/gradle.properties
@@ -1,0 +1,3 @@
+org.gradle.jvmargs=-Xmx2048m -Dfile.encoding=UTF-8
+android.useAndroidX=true
+android.enableJetifier=true

--- a/dream-diary/settings.gradle.kts
+++ b/dream-diary/settings.gradle.kts
@@ -1,0 +1,2 @@
+rootProject.name = "DreamTrackerAI"
+include(":app")


### PR DESCRIPTION
## Summary
- add a new `dream-diary` Android Studio project that implements a Compose based dream journal with AI-style analyses
- document how to run the sample and highlight its features in the root README

## Testing
- Not run (not requested)


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6918f9dafb788326a586050ba6e531ee)